### PR TITLE
change declaration output path in build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,4 +20,4 @@ esbuild ./src/index.ts \
     --minify
 
 # Generate .d.ts
-tsc
+tsc --project tsconfig.build.json

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+  {
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+      "removeComments": true /* Disable emitting comments. */,
+    },
+    "exclude": [
+      "test/*.ts",
+    ]
+  }


### PR DESCRIPTION
- ignores the test file declaration in distribution build.
- removes comments from declaration in distribution build (might not be recomended)
- places declration in the root of ./dist folder to solve resolution issue.