### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Configures [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) for npm and gh-actions updates.

Feel free to reject this PR, because it may not align with your way of doing things. You can just close this PR without any comment.